### PR TITLE
Calculate Net salary with date

### DIFF
--- a/src/net.js
+++ b/src/net.js
@@ -1,99 +1,107 @@
 
 const Big = require('big.js');
+const july23 = new Date("2023-07-01")
 
-module.exports = function net(gross, nguoiPhuThuoc, region = 1) {
+module.exports = function net(gross, dependents = 0, region = 1, date = july23) {
     const grossBig = new Big(gross);
-    console.log("Gross: ", grossBig.toNumber());
-    console.log("Dependents: ", nguoiPhuThuoc);
 
-   
-    var giamThueNguoiPhuThuoc = new Big(0);
-
-    if (nguoiPhuThuoc > 0) {
-
-        giamThueNguoiPhuThuoc = new Big(nguoiPhuThuoc *4400000);
-    }
-
-    console.log("So tien khau tru nguoi phu thuoc: ", giamThueNguoiPhuThuoc.toNumber());
-
-
-    //Gross > 93_600_000? regionMinWage*20: gross*0.01
     let regionMinWage;
+    let baseSalary;
+    // console.log('Date:', date.toISOString());
 
-    if (region === 1) {
-        regionMinWage = 4680000;
-    } else if (region === 2) {
-        regionMinWage = 4160000;
-    } else if (region === 3) {
-        regionMinWage = 3640000;
-    } else if (region === 4) {
-        regionMinWage = 3250000;
+    if (date.getTime() < july23.getTime()) {
+
+        baseSalary = new Big(1_490_000);
+        switch (region) {
+            case 1:
+                regionMinWage = new Big(4_420_000);
+                break;
+            case 2:
+                regionMinWage = new Big(3_920_000);
+                break;
+            case 3:
+                regionMinWage = new Big(3_430_000);
+                break;
+            case 4:
+                regionMinWage = new Big(3_070_000);
+                break;
+            default:
+                throw new Error("Invalid region entered. Please enter again! (1, 2, 3, 4)");
+        }
+
     } else {
-        console.log("Invalid region entered. Please enter again! (1, 2, 3, 4) ")
-    };
 
-    // Tính toán các khoản bảo hiểm xã hội
-    const maxGrossForInsurance = new Big(36000000);
-    const maxGrossAccidental = new Big(regionMinWage * 20);
+        baseSalary = new Big(1_800_000);
+        switch (region) {
+            case 1:
+                regionMinWage = new Big(4_680_000);
+                break;
+            case 2:
+                regionMinWage = new Big(4_160_000);
+                break;
+            case 3:
+                regionMinWage = new Big(3_640_000);
+                break;
+            case 4:
+                regionMinWage = new Big(3_250_000);
+                break;
+            default:
+                throw new Error("Invalid region entered. Please enter again! (1, 2, 3, 4)");
+        }
 
-    const BHXH = Math.min(maxGrossForInsurance.times(0.08), grossBig.times(0.08));
-    console.log("BHXH: ", BHXH);
-
-    const BHYT = Math.min(maxGrossForInsurance.times(0.015), grossBig.times(0.015));
-    console.log("BHYT: ", BHYT);
-
-    const BHTN = Math.min(maxGrossAccidental.times(0.01), grossBig.times(0.01));
-    console.log("BHTN: ", BHTN);
-
-
-    // Tính toán thu nhập chịu thuế
-    const grossIncome = grossBig.minus(BHXH).minus(BHYT).minus(BHTN);
-    console.log("Thu nhap truoc thue: ", grossIncome.toNumber());
-
-    const taxableIncome = grossIncome.minus(11000000).minus(giamThueNguoiPhuThuoc);
-    const taxableIncomeTemp = taxableIncome.gt(0) ? taxableIncome : new Big(0);
-
-    console.log("Thu nhap chiu thue: ", taxableIncomeTemp.toNumber())
-
-
-    // Tính toán thuế TNCN theo từng bậc thuế
-    const bac1 = Math.min(taxableIncomeTemp.toNumber(), 5000000);
-    const bac2 = Math.max(0, Math.min(taxableIncomeTemp.toNumber() - 5000000, 5000000));
-    const bac3 = Math.max(0, Math.min(taxableIncomeTemp.toNumber() - 10000000, 8000000));
-    const bac4 = Math.max(0, Math.min(taxableIncomeTemp.toNumber() - 18000000, 14000000));
-    const bac5 = Math.max(0, Math.min(taxableIncomeTemp.toNumber() - 32000000, 20000000));
-    const bac6 = Math.max(0, Math.min(taxableIncomeTemp.toNumber() - 52000000, 28000000));
-    const bac7 = Math.max(0, taxableIncomeTemp.toNumber() - 80000000);
-
-    // Tính toán thuế cho từng bậc
-    const thueBac1 = bac1 * 0.05;
-    const thueBac2 = bac2 * 0.1;
-    const thueBac3 = bac3 * 0.15;
-    const thueBac4 = bac4 * 0.2;
-    const thueBac5 = bac5 * 0.25;
-    const thueBac6 = bac6 * 0.3;
-    const thueBac7 = bac7 * 0.35;
-
-
-    // Tổng thuế thu nhập cá nhân
-    const tongThueTNCN = thueBac1 + thueBac2 + thueBac3 + thueBac4 + thueBac5 + thueBac6 + thueBac7;
-    console.log("Tong thue TNCN: ", tongThueTNCN);
-
-    // Tính toán thu nhập ròng (net)
-
-
-    if (taxableIncome.gt(0)) {
-        netSalary = grossIncome.minus(tongThueTNCN);
-    } else {
-        netSalary = grossIncome;
     }
-
-    console.log("netSalary: ", netSalary.toNumber());
-    console.log("____________________________")
-
-    return netSalary;
-
-};
+    const dependentTaxRelief = new Big(dependents * 4_400_000);
 
 
+// Calculating social insurance contributions
+const maxGrossForInsurance = new Big(baseSalary.times(new Big(20)));
+const maxGrossAccidental = new Big(regionMinWage.times(new Big(20)));
+
+const socialInsurance = maxGrossForInsurance.gt(grossBig) ? Big(grossBig.times(0.08)) : Big(maxGrossForInsurance.times(0.08));
+
+const healthInsurance = maxGrossForInsurance.gt(grossBig) ? Big(grossBig.times(0.015)) : Big(maxGrossForInsurance.times(0.015));
+
+const unemploymentInsurance = maxGrossAccidental.gt(grossBig) ? Big(grossBig.times(0.01)) : Big(maxGrossAccidental.times(0.01));
+
+
+// Calculating taxable income
+const afterInsurance = grossBig.minus(socialInsurance).minus(healthInsurance).minus(unemploymentInsurance);
+
+let taxableIncome = afterInsurance.minus(11000000).minus(dependentTaxRelief);
+
+taxableIncome = taxableIncome.gt(0) ? taxableIncome : new Big(0);
+
+const taxableIncomeRate1 = Big(taxableIncome).gt(Big(5000000)) ? Big(5000000) : taxableIncome;
+
+let taxableIncomeRate2 = Big(taxableIncome.minus(5000000)).lt(Big(5000000)) ? taxableIncome.minus(5000000) : Big(5000000);
+taxableIncomeRate2 = Big(0).gt(taxableIncomeRate2) ? Big(0) : taxableIncomeRate2;
+
+let taxableIncomeRate3 = Big(taxableIncome.minus(10000000)).lt(Big(8000000)) ? taxableIncome.minus(10000000) : Big(8000000);
+taxableIncomeRate3 = Big(0).gt(taxableIncomeRate3) ? Big(0) : taxableIncomeRate3;
+
+let taxableIncomeRate4 = Big(taxableIncome.minus(18000000)).lt(Big(14000000)) ? taxableIncome.minus(18000000) : Big(14000000);
+taxableIncomeRate4 = Big(0).gt(taxableIncomeRate4) ? Big(0) : taxableIncomeRate4;
+
+let taxableIncomeRate5 = Big(taxableIncome.minus(32000000)).lt(Big(20000000)) ? taxableIncome.minus(32000000) : Big(20000000);
+taxableIncomeRate5 = Big(0).gt(taxableIncomeRate5) ? Big(0) : taxableIncomeRate5;
+
+let taxableIncomeRate6 = Big(taxableIncome.minus(52000000)).lt(Big(28000000)) ? taxableIncome.minus(52000000) : Big(28000000);
+taxableIncomeRate6 = Big(0).gt(taxableIncomeRate6) ? Big(0) : taxableIncomeRate6;
+
+const taxableIncomeRate7 = Big(0).gt(Big(taxableIncome.minus(80000000))) ? Big(0) : Big(taxableIncome.minus(80000000));
+
+// Calculating tax by tax bracket
+const taxRate1 = new Big(taxableIncomeRate1).times(new Big(0.05));
+const taxRate2 = new Big(taxableIncomeRate2).times(new Big(0.1));
+const taxRate3 = new Big(taxableIncomeRate3).times(new Big(0.15));
+const taxRate4 = new Big(taxableIncomeRate4).times(new Big(0.2));
+const taxRate5 = new Big(taxableIncomeRate5).times(new Big(0.25));
+const taxRate6 = new Big(taxableIncomeRate6).times(new Big(0.3));
+const taxRate7 = new Big(taxableIncomeRate7).times(new Big(0.35));
+
+const totalTax = Big(taxRate1).add(Big(taxRate2)).add(Big(taxRate3)).add(Big(taxRate4)).add(Big(taxRate5)).add(Big(taxRate6)).add(Big(taxRate7));
+
+return afterInsurance.minus(totalTax).toNumber();
+
+}
 

--- a/test/net.test.js
+++ b/test/net.test.js
@@ -3,455 +3,257 @@ var net = require('../src/net.js')
 var assert = require('assert');
 var test = require('mocha').it;
 
-describe("CALCULATE NET SALARY:", function () {
-  console.log("*************************");
+describe("Calculate net salary", function () {
 
-  describe("Gross is lte 12.290500m (No tax)", function () {
-    describe("NO DEPENDENTS: ", function () {
+    describe('Check Net salary with dependent', function () {
+        //Personal Income Tax (PIT)
 
-      test('Gross is equal 12.290503m', () => {
+        test('No dependent deducted', function () {
+            //Gross income below 11 million is tax-exempt.
+            const netSalary = net(10_000_000);
 
+            assert.equal(netSalary, 8_950_000);
+        })
 
-        let netSalary = net(12290503, 0);
-        let roundedSalary = Math.round(netSalary);
+        test('Dependent with no taxable income', function () {
+            //afterInsurance below 11 million is tax-exempt.
+            const netSalary = net(10_000_000, 1);
 
-        assert.equal(roundedSalary, 11000000);
-      });
+            assert.equal(netSalary, 8_950_000);
+        })
 
-      test('Gross is lt 12.290500m', function () {
-        const netSalary = net(2000000, 0);
+        test('Taxes fully deducted with dependents', function () {
+            //11m < Gross - 10.5% Gross  <= 11m (Personal deductions) + 4.4m * dependents (Dependent deductions)
+            //12.29m < Gross <=17.2067m
+            const netSalary = net(13_000_000, 1);
 
-        assert.equal(netSalary.toNumber(), 1790000);
-      });
+            assert.equal(netSalary, 11_635_000);
+        })
 
-      test('Gross is almost 0', function () {
-        const netSalary = net(3, 0);
+        test('Taxes partially deducted with dependents', function () {
+            //Gross - 10.5% Gross  > 11m (Personal deductions) + 4.4m * dependents (Dependent deductions)
+            //Gross > 17.2067m
+            const netSalary = net(20_000_000, 1);
 
-        assert.equal(netSalary.toNumber(), 2.685);
-      });
-
-      test('Gross is eq 0', function () {
-        const netSalary = net(0, 0);
-
-        assert.equal(netSalary.toNumber(), 0);
-      });
+            assert.equal(netSalary, 17_775_000);
+        })
     })
 
-    describe("HAVING DEPENDENTS", function () {
+    describe('Check Net salary with Insurance', function () {
+
+        describe('Before 1/7/2023', function () {
+
+            test('Throw Exception when entering invalid region', function () {
+                assert.throws(function () {
+                    net(93_678_123, 0, 10, new Date("2023-06-01"));
+                }, Error, 'Invalid region entered. Please enter again! (1, 2, 3, 4)');
+
+            })
+
+            test('It applies 10.5% of Gross for all Insurance(SI 8%, HI 1.5% , UI 1%) when Gross Income is less than or equal 20 times Base Salary (29.8m)', function () {
+                //Gross Income <= 29.8 million:
+                // Social Insurance (SI): 8% Gross
+                // Health Insurance (HI): 1.5% Gross
+                // Unemployment Insurance (UI): 1% Gross
+
+                const netSalary = net(10, 0, 1, new Date("2023-06-01"));
+                assert.equal(netSalary, 8.95);
+            })
+
+            test('It applies max threshold (29.8m) for SI (8%) and HI (1.5%) when Gross between 29.8m and 88.4m', function () {
+                // SI: 8% of 29.8 million
+                // HI: 1.5% of 29.8 million
+                // UI: 1% of Gross Income
+
+                const netSalary = net(29_900_000, 0, 1, new Date("2023-06-01"));
+                assert.equal(netSalary, 25154500);
+            })
+
+            test('It applies max threshold (88.4m) of region 1 for UI (1%)', function () {
+                // SI: 8% of 29.8 million
+                // HI: 1.5% of 29.8 million
+                // UI (Region 1): 1% of 20 * 4.42 (88.4 million)
+
+                const netSalary = net(88_888_888, 0, 1, new Date("2023-06-01"));
+                assert.equal(netSalary, 68_771_721.6);
+            })
+
+
+            test('It applies max threshold (78.4m) of region 2 for UI (1%)', function () {
+                // SI: 8% of 29.8 million
+                // HI: 1.5% of 29.8 million
+                // UI (Region 2): 1% of 20 * 3.92 (78.4 million) 
+                const netSalary = net(88_888_888, 0, 2, new Date("2023-06-01"));
+                assert.equal(netSalary, 68841721.6);
+            })
+
+            test('It applies max threshold (68.6m) of region 3 for UI (1%)', function () {
+                // SI: 8% of 29.8 million
+                // HI: 1.5% of 29.8 million
+                // UI (Region 3): 1% of 20 * 3.43 (68.6 million)
+                const netSalary = net(88_888_888, 0, 3, new Date("2023-06-01"));
+                assert.equal(netSalary, 68_910_321.6);
+            })
+
+
+            test('It applies max threshold (61.4m) of region 4 for UI (1%)', function () {
+                // SI: 8% of 29.8 million
+                // HI: 1.5% of 29.8 million
+                // UI (Region 4): 1% of 20 * 3.07 (61.4 million)
+                const netSalary = net(88_888_888, 0, 4, new Date("2023-06-01"));
+                assert.equal(netSalary, 68_960_721.6);
+            })
+
+        })
+        describe('After 1/7/2023', function () {
+
+            test('Throw Exception when entering invalid region, after 1/7/2023', function () {
+                assert.throws(function () {
+                    net(93_678_123, 0, 10);
+                }, Error, 'Invalid region entered. Please enter again! (1, 2, 3, 4)');
+
+            })
+
+            test('It applies 10.5% of Gross for all Insurance(SI 8%, HI 1.5% , UI 1%) when Gross Income is less than or equal 20 times Base Salary (36m)', function () {
+                // Social Insurance (SI): 8% gross 
+                // Health Insurance (HI): 1.5% gross
+                // Unemployment Insurance (UI): 1% gross
+
+                const netSalary = net(31_234_456);
+                assert.equal(netSalary, 26_161_612.402);
+            })
+
+            test('It applies max threshold (36m) for SI (8%) and HI (1.5%) when Gross between 36m and 93.6m', function () {
+                // SI: 8% of 36 million
+                // HI: 1.5% of 36 million
+                // UI: 1% of Gross Income
+
+                const netSalary = net(36_789_123);
+                assert.equal(netSalary, 30_250_985.416);
+            })
+
+            test('It applies max threshold (93.6m) of region 1 for UI (1%)', function () {
+                // SI: 8% of 36 million
+                // HI: 1.5% of 36 million
+                // UI (Region 1): 1% of 20 * 4.68 (93.6 million)
+
+                const netSalary = net(93_678_123);
+                assert.equal(netSalary, 71_675_486.1);
+            })
 
-      test('Gross is equal 12.290503m ', () => {
 
-        let netSalary = net(12290503, 1);
-        let roundedSalary = Math.floor(netSalary);
+            test('It applies max threshold (83.2m) of region 2 for UI (1%)', function () {
+                // SI: 8% of 36 million
+                // HI: 1.5% of 36 million
+                // UI (Region 2): 1% of 20 * 4.16 (83.2 million) 
 
-        assert.equal(roundedSalary, 11000000);
-      });
-    })
+                const netSalary = net(93_678_123, 0, 2);
+                assert.equal(netSalary, 71_748_286.1);
+            })
 
-    describe("Gross is gt 12.290503m (tax)", function () {
+            test('It applies max threshold (72.8m) of region 3 for UI (1%)', function () {
+                // SI: 8% of 36 million
+                // HI: 1.5% of 36 million
+                // UI (Region 3): 1% of 20 * 3.64 (72.8 million)
 
-      describe("NO DEPENDENTS: ", function () {
+                const netSalary = net(93_678_123, 0, 3);
+                assert.equal(netSalary, 71_821_086.1);
+            })
 
-        test('Taxable income is lte 5m', () => {
-          const netSalary = net(16000000, 0);
+            test('It applies max threshold (65m) of region 4 for UI (1%)', function () {
+                // SI: 8% of 36 million
+                // HI: 1.5% of 36 million
+                // UI (Region 4): 1% of 20 * 3.25 (65 million) 
 
-          assert.equal(netSalary.toNumber(), 14154000);
-        });
+                const netSalary = net(93_678_123, 0, 4);
+                assert.equal(netSalary, 71_875_686.1);
+            })
 
-        test('Taxable income is lte 5m (region 2)', () => {
-          const netSalary = net(16000000, 0, 2);
 
-          assert.equal(netSalary.toNumber(), 14154000);
-        });
-        //______________________________________________
+        })
+    });
 
-        test('Taxable income is gt 5m and lt 10m', () => {
-          const netSalary = net(20000000, 0);
+    describe('Check Net salary with 7 rates of taxes: ', function () {
 
-          assert.equal(netSalary.toNumber(), 17460000);
-        });
+        /**
+         * gross = NET + tax + inssurance
+         * Case 1: inssurance + dont have taxableIncome
+         * => NET = Gross - gross*10.5%
+         * Case 2: inssurance + have taxableIncome ()
+         * => NET = Gross - tax - gross*10.5% - dependents
+         * 
+         */
+        test('It applies no tax', function () {
+            //afterInsurance below 11 million is tax-exempt.
+            //Gross - 10.5% Gross < 11m (Personal deductions)
+            // Gross < 12.29m
+            const netSalary = net(12_000_000);
 
-        test('Taxable income is eq 10m', () => {
-          const netSalary = net(23463687, 0);
+            assert.equal(netSalary, 10_740_000);
+        })
 
-          assert.equal(netSalary.toNumber(), 20249999.8785);
-        });
-        //_______________________________________________
+        test('It applies tax rate 1 only', function () {
+            //11m < Gross - 10.5% Gross < 11m + 5m (taxRate1)
+            //12.29m < Gross <17.87
+            const netSalary = net(16_789_000);
 
-        test('Taxable income is gt 10m and lt 18m', () => {
-          let netSalary = net(29050280, 0);
+            assert.equal(netSalary, 14_824_847.25);
+        })
 
-          assert.equal(netSalary.toNumber(), 24500000.51);
-        });
+        test('It applies 2 first tax rates', function () {
+            //16m < Gross - 10.5% Gross < 11m + 5m (taxRate1) +  5m (taxRate2)
+            //17.87m <Gross < 23.46m
+            const netSalary = net(19_789_000);
 
-        test('Taxable income is eq 18m', () => {
-          let netSalary = net(32402235, 0);
+            assert.equal(netSalary, 17_290_039.5);
+        })
 
-          assert.equal(netSalary.toNumber(), 27050000.26);
-        });
-        //___________________________________________
+        test('It applies 3 first tax rates', function () {
+            //21m < Gross - 10.5% Gross < 11m + 5m (taxRate1) +  5m (taxRate2) + 8m (taxRate3)
+            //23.46m < Gross < 32.4m
+            const netSalary = net(24_023_355);
 
-        test('Taxable income is gt 18m and lt 32m', () => {
-          let netSalary = net(32402236, 0);
+            assert.equal(netSalary, 20_675_767.31625);
+        })
 
-          assert.equal(netSalary.toNumber(), 27050000.976);
-        });
+        test('It applies 4 first tax rates', function () {
+            //29m < Gross - 10.5% Gross &&  Gross - 8%*36_000_000 - 1.5%*36_000_000 - 1%* Gross (Gross < 20 * regionMinWage) < 11m + 5m (taxRate1) +  5m (taxRate2) + 8m (taxRate3) + 14m (taxRate4)
+            //32.402235m < Gross < 46_888_888,89
 
-        test('Taxable income is eq 32m', () => {
-          let netSalary = net(47884187, 0);
+            const netSalary = net(34_398_344);
 
-          assert.equal(netSalary.toNumber(), 38989008.8475);
-        });
-        //_____________________________________________
+            assert.equal(netSalary, 28_479_214.304);
+        })
 
-        test('Taxable income is gt 32m and lt 52m', () => {
-          let netSalary = net(60900000, 0);
+        test('It applies 5 first tax rates', function () {
+            //43m < Gross - 8%*36_000_000 - 1.5%*36_000_000 - 1%* Gross (Gross < 20 * regionMinWage) < 11m + 5m (taxRate1) +  5m (taxRate2) + 8m (taxRate3) + 14m (taxRate4) + 20m(taxRate5)
+            //46_888_888,89m < Gross < 67_090_909,09m
 
-          assert.equal(netSalary.toNumber(), 48653250);
-        });
+            const netSalary = net(48_003_947);
 
-        test('Taxable income is eq 52m', () => {
-          let netSalary = net(67_090_909, 0);
+            assert.equal(netSalary, 39_077_930.6475);
+        })
 
-          assert.equal(netSalary.toNumber(), 53_249_999.9325);
-        });
+        test('It applies 6 first tax rates', function () {
+            //63m < Gross - 8%*36_000_000 - 1.5%*36_000_000 - 1%* Gross (Gross < 20 * regionMinWage) < 11m + 5m (taxRate1) +  5m (taxRate2) + 8m (taxRate3) + 14m (taxRate4) + 20m(taxRate5) + 28m (taxRate6)
+            //67_090_909,09m < Gross < 95_373_737,37m
 
-        test('Taxable income is gt 52m and lt 80m', () => {
-          let netSalary = net(70_000_000, 0, 1);
+            const netSalary = net(68_033_567);
 
-          assert.equal(netSalary.toNumber(), 55_266_000);
-        });
-        //__________________________________________
+            assert.equal(netSalary, 53_903_261.931);
+        })
 
-        test('Gross is eq 93.6m (test BHTN), dependent 0, region 1', () => {
-          let netSalary = net(93_600_000, 0, 1);
+        test('It applies with all 7 tax rates', function () {
+            // Gross - 8%*36_000_000 - 1.5%*36_000_000 - 1% * 93_600_000 > 80m +11m
+            // gross > 95_356_000
 
-          assert.equal(netSalary.toNumber(), 71_620_800);
-        });
+            const netSalary = net(95_356_001);
 
-        test('Gross is gt 93.6m (test BHTN), dependent 0, region 1', () => {
-          let netSalary = net(95_000_000, 0, 1);
-
-          assert.equal(netSalary.toNumber(), 72_600_800);
-        });
-
-        test('Gross is gt 93.6m (test BHTN), dependent 0, region 2', () => {
-          let netSalary = net(95_000_000, 0, 2);
-
-          assert.equal(netSalary.toNumber(), 72_673_600);
-        });
-
-        test('Gross is gt 93.6m (test BHTN), dependent 0, region 3', () => {
-          let netSalary = net(95_000_000, 0, 3);
-
-          assert.equal(netSalary.toNumber(), 72_746_400);
-        });
-
-        test('Gross is gt 93.6m (test BHTN), dependent 0, region 4', () => {
-          let netSalary = net(95_000_000, 0, 4);
-
-          assert.equal(netSalary.toNumber(), 72_801_000);
-        });
-        //____________________________________
-
-        test('Taxable income is eq 80m', () => {
-          let netSalary = net(95_356_000, 0, 1);
-
-          assert.equal(netSalary.toNumber(), 72_850_000);
-        });
-
-        test('Taxable income is eq 80m, region 2)', () => {
-          let netSalary = net(95_356_000, 0, 2);
-
-          assert.equal(netSalary.toNumber(), 72_917_600);
-        });
-
-        test('Taxable income is eq 80m, region 3)', () => {
-          let netSalary = net(95_356_000, 0, 3);
-
-          assert.equal(netSalary.toNumber(), 72_985_200);
-        });
-        
-        test('Taxable income is eq 80m, region 4)', () => {
-          let netSalary = net(95_356_000, 0, 4);
-
-          assert.equal(netSalary.toNumber(), 73_035_900);
-        });
-
-
-        test('Taxable income is gt 80m ', () => {
-          let netSalary = net(100_000_000, 0, 4);
-
-          assert.equal(netSalary.toNumber(), 76_054_500);
-        });
-
-        test('Taxable income is gt 80m, region 2)', () => {
-          let netSalary = net(100_000_000, 0, 2);
-
-          assert.equal(netSalary.toNumber(), 75_936_200);
-        });
-      
-
-      })
-      //_______________________________________________
-
-      describe("HAVING DEPENDENTS: ", ()=>{
-
-        test('Taxable income is lt 5m (taxincome eq 0, dependent 1)', () => {
-          const netSalary = net(16_000_000, 1, 1);
-
-          assert.equal(netSalary.toNumber(), 14_320_000);
-        });
-
-        test('Taxable income is lt 5m (taxincome eq 0, dependent 2)', () => {
-          const netSalary = net(16_000_000, 2, 1);
-
-          assert.equal(netSalary.toNumber(), 14_320_000);
-        });
-
-        test('Taxable income is eq 5m (taxincome eq 0, dependent 1)', () => {
-          const netSalary = net(17_206_704, 1, 1);
-
-          assert.equal(netSalary.toNumber(), 15400000.076);
-        });
-
-        test('Taxable income is gt 5m and lt 10m, dependent 1)', () => {
-          const netSalary = net(20_000_000, 1, 1);
-
-          assert.equal(netSalary.toNumber(), 17_775_000);
-        });
-
-        test('Taxable income is gt 5m and lt 10m, dependent 2)', () => {
-          const netSalary = net(20_000_000, 2, 1);
-
-          assert.equal(netSalary.toNumber(), 17_900_000);
-        });
-
-        test('Taxable income is eq 10m, dependent 1', () => {
-          const netSalary = net(23463687, 1);
-
-          assert.equal(netSalary.toNumber(), 20_689_999.8785);
-        });
-
-        test('Taxable income is eq 10m, dependent 2', () => {
-          const netSalary = net(23463687, 2);
-
-          assert.equal(netSalary.toNumber(), 20_939_999.87175);
-        });
-
-        test('Taxable income is eq 10m, dependent 3', () => {
-          const netSalary = net(23463687, 3);
-
-          assert.equal(netSalary.toNumber(), 20_999_999.865);
-        });
-
-        test('Taxable income is gt 10m and lt 18m, dependent 1', () => {
-          let netSalary = net(29050280, 1);
-
-          assert.equal(netSalary.toNumber(), 25_160_000.51);
-        });
-
-        test('Taxable income is gt 10m and lt 18m, dependent 2', () => {
-          let netSalary = net(29050280, 2);
-
-          assert.equal(netSalary.toNumber(), 25_630_000.54);
-        });
-
-        test('Taxable income is gt 10m and lt 18m, dependent 3', () => {
-          let netSalary = net(29050280, 3);
-
-          assert.equal(netSalary.toNumber(), 25_910_000.57);
-        });
-
-        test('Taxable income is gt 10m and lt 18m, dependent 4', () => {
-          let netSalary = net(29050280, 4);
-
-          assert.equal(netSalary.toNumber(), 26_000_000.6);
-        });
-       // _____________________________
-
-        test('Taxable income is eq 18m, dependent 1', () => {
-          let netSalary = net(32402235, 1);
-
-          assert.equal(netSalary.toNumber(), 27_710_000.27625);
-        });
-
-        test('Taxable income is eq 18m, dependent 2', () => {
-          let netSalary = net(32_402_235, 2);
-
-          assert.equal(netSalary.toNumber(), 28_330_000.2925);
-        });
-
-        test('Taxable income is eq 18m, dependent 3', () => {
-          let netSalary = net(32_402_235, 3);
-
-          assert.equal(netSalary.toNumber(), 28_760_000.30875);
-        });
-
-        test('Taxable income is eq 18m, dependent 4', () => {
-          let netSalary = net(32_402_235, 4);
-
-          assert.equal(netSalary.toNumber(), 28_980_000.30875);
-        });
-        
-        test('Taxable income is eq 18m, dependent 5', () => {
-          let netSalary = net(32_402_235, 5);
-
-          assert.equal(netSalary.toNumber(), 29_000_000.325);
-        });
-        //_________________________________
-
-        test('Taxable income is gt 18m and lt 32m, dependent 1', () => {
-          let netSalary = net(32_402_236, 1);
-
-          assert.equal(netSalary.toNumber(), 27_710_001.037);
-        });
-
-        test('Taxable income is gt 18m and lt 32m, dependent 2', () => {
-          let netSalary = net(32_402_236, 2);
-
-          assert.equal(netSalary.toNumber(), 28_330_001.098);
-        });
-
-        test('Taxable income is gt 18m and lt 32m, dependent 3', () => {
-          let netSalary = net(32_402_236, 3);
-
-          assert.equal(netSalary.toNumber(), 28_760_001.159);
-        });
-
-        test('Taxable income is gt 18m and lt 32m, dependent 4', () => {
-          let netSalary = net(32_402_236, 4);
-
-          assert.equal(netSalary.toNumber(), 28_980_001.159);
-        });
-        
-        test('Taxable income is gt 18m and lt 32m, dependent 5', () => {
-          let netSalary = net(32_402_236, 5);
-
-          assert.equal(netSalary.toNumber(), 29_000_001.22);
-        });
-        //_____________________________________
-
-        test('Taxable income is eq 32m, dependent 1', () => {
-          let netSalary = net(47_884_187, 1);
-
-          assert.equal(netSalary.toNumber(), 39_918_276.104);
-        });
-
-        test('Taxable income is eq 32m, dependent 2', () => {
-          let netSalary = net(47_884_187, 2);
-
-          assert.equal(netSalary.toNumber(), 40_798_276.104);
-        });
-
-        test('Taxable income is eq 32m, dependent 8', () => {
-          let netSalary = net(47_884_187, 8);
-
-          assert.equal(netSalary.toNumber(), 43_985_345.13);
-        });
-        //______________________________________
-
-
-
-        test('Taxable income is gt 32m and lt 52m, dependent 1', () => {
-          let netSalary = net(60_900_000, 1);
-
-          assert.equal(netSalary.toNumber(), 49_753_250);
-        });
-
-        test('Taxable income is gt 32m and lt 52m, dependent 11', () => {
-          let netSalary = net(60_900_000, 11);
-
-          assert.equal(netSalary.toNumber(), 56_871_000);
-        });
-
-        //_________________________________________________
-
-        test('Taxable income is gt 52m and lt 80m, dependent 1, region 1', () => {
-          let netSalary = net(68000000, 1, 1);
-
-          assert.equal(netSalary.toNumber(), 55_025_000);
-        });
-
-        
-        test('Gross is eq 93.6m and taxable income lt 80m (test BHTN), dependent 1, region 1', () => {
-          let netSalary = net(93_600_000, 1, 1);
-
-          assert.equal(netSalary.toNumber(), 72_940_800);
-        });
-
-        
-        test('Gross is gt 93.6m and taxable income lt 80m (test BHTN), dependent 1, region 1', () => {
-          let netSalary = net(95_000_000, 1, 1);
-
-          assert.equal(netSalary.toNumber(), 73_920_800);
-        });
-
-        test('Gross is gt 93.6m and taxable income lt 80m (test BHTN), dependent 1, region 2', () => {
-          let netSalary = net(95_000_000, 1, 2);
-
-          assert.equal(netSalary.toNumber(), 73_993_600);
-        });
-
-        test('Gross is gt 93.6m and taxable income lt 80m (test BHTN), dependent 1, region 3', () => {
-          let netSalary = net(95_000_000, 1, 3);
-
-          assert.equal(netSalary.toNumber(), 74_066_400);
-        });
-
-        test('Gross is gt 93.6m and taxable income lt 80m (test BHTN), dependent 1, region 4', () => {
-          let netSalary = net(95_000_000, 1, 4);
-
-          assert.equal(netSalary.toNumber(), 74_121_000);
-        });
-
-        test('Gross is gt 93.6m and taxable income lt 80m (test BHTN), dependent 19, region 4', () => {
-          let netSalary = net(95_000_000, 19, 1);
-
-          assert.equal(netSalary.toNumber(), 90_644_000);
-        });
-        //_____________________________
-
-        test('Taxable income is eq 80m, dependent 1, region 1', () => {
-          let netSalary = net(95_356_000, 1, 1);
-
-          assert.equal(netSalary.toNumber(), 74_170_000);
-        });
-
-        test('Taxable income is eq 80m, dependent 5, region 4', () => {
-          let netSalary = net(95_356_000, 5, 4);
-
-          assert.equal(netSalary.toNumber(), 79_650_200);
-        });
-        //______________________________
-
-        test('Taxable income is gt 80m, dependent 1, region 1', () => {
-          let netSalary = net(100_000_000, 1, 1);
-
-          assert.equal(netSalary.toNumber(), 77_408_600);
-        });
-
-        test('Taxable income is gt 80m, dependent 1, region 2', () => {
-          let netSalary = net(100_000_000, 1, 2);
-
-          assert.equal(netSalary.toNumber(), 77_476_200);
-        });
-
-        test('Taxable income is gt 80m, dependent 1, region 3', () => {
-          let netSalary = net(100_000_000, 1, 3);
-
-          assert.equal(netSalary.toNumber(), 77_543_800);
-        });
-
-        test('Taxable income is gt 80m, dependent 1, region 4', () => {
-          let netSalary = net(100_000_000, 1, 4);
-
-          assert.equal(netSalary.toNumber(), 77_594500);
-        });
- 
-      })
+            assert.equal(netSalary, 72_850_000.65);
+        })
 
     })
 
-  })
 })
+
+


### PR DESCRIPTION
Calculate Net salary with date: Before 01-07-2023 and after 01-07-2023 will have different basic salaries.

- [x] Separate test case group by modules (insurance calc module, tax module, and integrate all module)
- [x] Rephrase all test case name to be Descriptive